### PR TITLE
Implement cursor pagination by following JSONAPI standard on pagination

### DIFF
--- a/app/contracts/base_list_contract.rb
+++ b/app/contracts/base_list_contract.rb
@@ -1,6 +1,8 @@
 class BaseListContract < ApplicationContract
   params do
-    optional(:per_page).value(:integer, gt?: 0, lteq?: 100)
-    optional(:page).value(:integer)
+    optional(:page).hash do
+      optional(:size).value(:integer, gt?: 0, lteq?: 100)
+      optional(:number).value(:integer)
+    end
   end
 end

--- a/app/contracts/freights/search_carrier_contract.rb
+++ b/app/contracts/freights/search_carrier_contract.rb
@@ -1,9 +1,12 @@
 module Freights
   class SearchCarrierContract < ApplicationContract
-    params(BaseListContract.schema) do
+    params do
       required(:id).value(:integer)
       required(:sort).value(:string, included_in?: %w[closest cheapest])
-      required(:per_page).value(:integer, gt?: 0, lteq?: 10)
+      required(:page).hash do
+        required(:size).value(:integer, gt?: 0, lteq?: 10)
+        optional(:number).value(:integer)
+      end
     end
   end
 end

--- a/app/filters/paginate_filter.rb
+++ b/app/filters/paginate_filter.rb
@@ -7,9 +7,10 @@ class PaginateFilter
   DEFAULT_PAGE_SIZE = 30
 
   def call(model, attrs = {})
+    size, number = attrs.fetch(:page, {}).slice(:size, :number).values
     Success(
-      model.page(attrs[:page] || DEFAULT_PAGE)
-          .per(attrs[:per_page] || DEFAULT_PAGE_SIZE)
+      model.page(number || DEFAULT_PAGE)
+          .per(size || DEFAULT_PAGE_SIZE)
     )
   end
 end

--- a/app/operations/concerns/base_filter_operation.rb
+++ b/app/operations/concerns/base_filter_operation.rb
@@ -14,8 +14,8 @@ module BaseFilterOperation
 
     def call(input)
       parameters = (yield contract.call(input).to_monad).to_h
-      result = yield paginate.call(model, parameters.slice(:page, :per_page))
-      Success(result.where(parameters.except(:page, :per_page)))
+      result = yield paginate.call(model, parameters.slice(:page))
+      Success(result.where(parameters.except(:page)))
     end
   end
 end

--- a/app/operations/freights/search_carriers_operation.rb
+++ b/app/operations/freights/search_carriers_operation.rb
@@ -28,7 +28,7 @@ module Freights
       filter = filter_factory.from_sort_type(contract[:sort])
 
       result = yield filter.call(resource)
-      paginate.call(result, contract.slice(:page, :per_page))
+      paginate.call(result, contract.slice(:page))
     end
 
     private

--- a/spec/contracts/base_list_contract_spec.rb
+++ b/spec/contracts/base_list_contract_spec.rb
@@ -3,26 +3,32 @@ RSpec.describe BaseListContract, type: :contract do
 
   describe '.call' do
     subject(:call) { contract.call(input) }
-    context 'when the per_page attribute is equal to 0' do
-      let(:input) { { per_page: 0, ignored: 'abc' } }
-
-      its(:'errors.to_h') { is_expected.to eql(per_page: ['must be greater than 0']) }
-    end
-
-    context 'when the per_page attribute is greater than 100' do
-      let(:input) { { per_page: 101, ignored: 'abc' } }
+    context 'when the page size attribute is equal to 0' do
+      let(:input) { { page: { size: 0 }, ignored: 'abc' } }
 
       its(:'errors.to_h') do
-        is_expected.to eql(per_page:
-          ['must be less than or equal to 100'])
+        is_expected.to eql(page: { size: ['must be greater than 0'] })
+      end
+    end
+
+    context 'when the page size attribute is greater than 100' do
+      let(:input) { { page: { size: 101 }, ignored: 'abc' } }
+
+      its(:'errors.to_h') do
+        is_expected.to eql(page: { size:
+          ['must be less than or equal to 100'] })
       end
     end
 
     context 'when the provided input is valid' do
-      let(:input) { { per_page: 10, ignored: 'abc', page: 10 } }
+      let(:input) { { page: { size: 100, number: 1 }, ignored: 'abc' } }
 
       its(:'errors.to_h') { is_expected.to be_empty }
-      its(:to_h) { is_expected.to eq({ per_page: input[:per_page], page: input[:page] }) }
+      its(:to_h) do
+        is_expected.to eq(
+          page: { size: input[:page][:size], number: input[:page][:number] }
+        )
+      end
     end
   end
 end

--- a/spec/contracts/carriers/list_contract_spec.rb
+++ b/spec/contracts/carriers/list_contract_spec.rb
@@ -3,34 +3,38 @@ RSpec.describe Carriers::ListContract, type: :contract do
 
   describe '.call' do
     subject(:call) { contract.call(input) }
-    context 'when the per_page attribute is equal to 0' do
-      let(:input) { { per_page: 0, ignored: 'abc' } }
-
-      its(:'errors.to_h') { is_expected.to include(per_page: ['must be greater than 0']) }
-    end
-
-    context 'when the per_page attribute is greater than 100' do
-      let(:input) { { per_page: 101, ignored: 'abc' } }
+    context 'when the page size attribute is equal to 0' do
+      let(:input) { { page: { size: 0 }, ignored: 'abc' } }
 
       its(:'errors.to_h') do
-        is_expected.to include(per_page:
-          ['must be less than or equal to 100'])
+        is_expected.to include(page: { size: ['must be greater than 0'] })
+      end
+    end
+
+    context 'when the page size attribute is greater than 100' do
+      let(:input) { { page: { size: 101 }, ignored: 'abc' } }
+
+      its(:'errors.to_h') do
+        is_expected.to include(page: { size:
+          ['must be less than or equal to 100'] })
       end
     end
 
     context 'when the shipping_carrier_id attribute is missing' do
-      let(:input) { { per_page: 10, ignored: 'abc', page: 10 } }
+      let(:input) { { ignored: 'abc', page: { size: 1, number: 1 } } }
 
       its(:'errors.to_h') { is_expected.to include(shipping_carrier_id: ['is missing']) }
     end
 
     context 'when the provided input is valid' do
-      let(:input) { { per_page: 10, ignored: 'abc', page: 10, shipping_carrier_id: 1 } }
+      let(:input) do
+        { ignored: 'abc', page: { size: 1, number: 1 }, shipping_carrier_id: 1 }
+      end
 
       its(:'errors.to_h') { is_expected.to be_empty }
       its(:to_h) do
         is_expected.to eq(
-          per_page: input[:per_page], page: input[:page],
+          page: { size: input[:page][:size], number: input[:page][:number] },
           shipping_carrier_id: input[:shipping_carrier_id]
         )
       end

--- a/spec/contracts/freights/search_carrier_contract_spec.rb
+++ b/spec/contracts/freights/search_carrier_contract_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Freights::SearchCarrierContract, type: :contract do
     subject(:call) { contract.call(input) }
     let(:valid_input) do
       {
-        id: 1, sort: 'closest', page: 1, per_page: 10
+        id: 1, sort: 'closest', page: { number: 1, size: 10 }
       }
     end
 
@@ -15,7 +15,17 @@ RSpec.describe Freights::SearchCarrierContract, type: :contract do
       its(:'errors.to_h') do
         is_expected.to eql(
           id: ['is missing'], sort: ['is missing'],
-          per_page: ['is missing']
+          page: ['is missing']
+        )
+      end
+    end
+
+    context 'when the page size paramenter is missing' do
+      let(:input) { valid_input.merge(page: {}) }
+
+      its(:'errors.to_h') do
+        is_expected.to eql(
+          page: { size: ['is missing'] }
         )
       end
     end
@@ -36,18 +46,20 @@ RSpec.describe Freights::SearchCarrierContract, type: :contract do
       end
     end
 
-    context 'when the per_page attribute is equal to 0' do
-      let(:input) { valid_input.merge(per_page: 0) }
-
-      its(:'errors.to_h') { is_expected.to eq(per_page: ['must be greater than 0']) }
-    end
-
-    context 'when the per_page attribute is greater than 10' do
-      let(:input) { valid_input.merge(per_page: 11) }
+    context 'when the page size attribute is equal to 0' do
+      let(:input) { valid_input.merge(page: { size: 0 }) }
 
       its(:'errors.to_h') do
-        is_expected.to include(per_page:
-          ['must be less than or equal to 10'])
+        is_expected.to eq(page: { size: ['must be greater than 0'] })
+      end
+    end
+
+    context 'when the page size attribute is greater than 10' do
+      let(:input) { valid_input.merge(page: { size: 11 }) }
+
+      its(:'errors.to_h') do
+        is_expected.to include(page: { size:
+          ['must be less than or equal to 10'] })
       end
     end
 
@@ -56,7 +68,7 @@ RSpec.describe Freights::SearchCarrierContract, type: :contract do
 
       its(:'errors.to_h') { is_expected.to be_empty }
       its(:to_h) do
-        is_expected.to eq(id: 1, sort: 'closest', page: 1, per_page: 10)
+        is_expected.to eq(id: 1, sort: 'closest', page: { number: 1, size: 10 })
       end
     end
   end

--- a/spec/filters/paginate_filter_spec.rb
+++ b/spec/filters/paginate_filter_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe PaginateFilter, type: :filters do
     end
 
     context 'paginate with provided attributes' do
-      let(:input) { { per_page: 1, page: 3 } }
-      its(:'success.limit_value') { is_expected.to eql(input[:per_page]) }
-      its(:'success.current_page') { is_expected.to eql(input[:page]) }
+      let(:input) { { page: { size: 1, number: 3 } } }
+      its(:'success.limit_value') { is_expected.to eql(input[:page][:size]) }
+      its(:'success.current_page') { is_expected.to eql(input[:page][:number]) }
     end
   end
 end

--- a/spec/operations/carriers/list_operation_spec.rb
+++ b/spec/operations/carriers/list_operation_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Carriers::ListOperation, type: :operation do
     let(:paginate_result) { success(Carrier.all) }
     let(:contract_result) { validation_contract(input: valid_input) }
 
-    let(:input) { { ignored: 'abcs', per_page: 99, page: 1 } }
-    let(:valid_input) { { per_page: 99, page: 1 } }
+    let(:input) { { ignored: 'abcs', page: { size: 99, number: 1 } } }
+    let(:valid_input) { { page: { size: 99, number: 1 } } }
 
     before do
       allow(paginate_filter).to receive(:call).and_return(paginate_result)
@@ -36,7 +36,7 @@ RSpec.describe Carriers::ListOperation, type: :operation do
     it do
       call
       expect(paginate_filter).to have_received(:call)
-        .with(Carrier, input.slice(:per_page, :page))
+        .with(Carrier, input.slice(:page))
     end
 
     it do

--- a/spec/operations/freights/search_carriers_operation_spec.rb
+++ b/spec/operations/freights/search_carriers_operation_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe Freights::SearchCarriersOperation, type: :operation do
       {
         id: freight.id,
         sort: 'sort-method',
-        page: 1,
-        per_page: 10
+        page: { size: 10, number: 1 }
       }
     end
 
@@ -58,7 +57,7 @@ RSpec.describe Freights::SearchCarriersOperation, type: :operation do
     it do
       call
       expect(paginate_filter).to have_received(:call)
-        .with(filter_result.value!, input.slice(:page, :per_page))
+        .with(filter_result.value!, input.slice(:page))
     end
 
     context 'when contract validation has failed' do

--- a/spec/operations/shipping_carriers/list_operation_spec.rb
+++ b/spec/operations/shipping_carriers/list_operation_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe ShippingCarriers::ListOperation, type: :operation do
     let(:paginate_result) { success(ShippingCarrier.all) }
     let(:contract_result) { validation_contract(input: valid_input) }
 
-    let(:input) { { ignored: 'abcs', per_page: 99, page: 1 } }
-    let(:valid_input) { { per_page: 99, page: 1 } }
+    let(:input) { { ignored: 'abcs', page: { size: 99, number: 1 } } }
+    let(:valid_input) { { page: { size: 99, number: 1 } } }
 
     before do
       allow(paginate_filter).to receive(:call).and_return(paginate_result)
@@ -36,7 +36,7 @@ RSpec.describe ShippingCarriers::ListOperation, type: :operation do
     it do
       call
       expect(paginate_filter).to have_received(:call)
-        .with(ShippingCarrier, input.slice(:per_page, :page))
+        .with(ShippingCarrier, input.slice(:page))
     end
 
     it do


### PR DESCRIPTION
The pagination's parameters are not according to JSONAPI. By following the [specification](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/#auto-id-query-parameters) the query parameters to paginate MUST be page [size] and page [number]. This commit changes the API implementation to use this specification instead: per_page and: page