### PR TITLE
Allow to cascade delete carriers association 

### DIFF
--- a/app/models/shipping_carrier.rb
+++ b/app/models/shipping_carrier.rb
@@ -1,5 +1,8 @@
 class ShippingCarrier < ApplicationRecord
   validates :name, :document, presence: true
 
-  has_many :carriers
+  # Allow to cascade delete carriers association.
+  # In the future, the carriers can not be deleted if any
+  # shipment has associeted.
+  has_many :carriers, dependent: :destroy
 end

--- a/spec/models/shipping_carrier_spec.rb
+++ b/spec/models/shipping_carrier_spec.rb
@@ -2,5 +2,5 @@ RSpec.describe ShippingCarrier, type: :model do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:document) }
 
-  it { is_expected.to have_many(:carriers) }
+  it { is_expected.to have_many(:carriers).dependent(:destroy) }
 end


### PR DESCRIPTION
Allow to cascade delete carriers association when a shipping_carrier is deleting

In the future, the carriers can not be deleted if any shipment has associated.